### PR TITLE
Add sublime_black menu in Preferences menu

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -18,7 +18,7 @@
         "caption": "Preferences: Black Settings - Default",
         "command": "open_file", "args":
         {
-            "file": "${packages}/Black/black.sublime-settings"
+            "file": "${packages}/sublime_black/black.sublime-settings"
         }
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,34 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "sublime_black",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/sublime_black/black.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/black.sublime-settings"},
+                                "caption": "Settings – User"
+                            },
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This PR copies the default settings in the Preferences folder and also sets up menu-items for sublime_black in the `Preferences` menu. This makes it easier for the user to configure the Plugin.